### PR TITLE
fix anaconda path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 # Install requirements for Python 3
-RUN /home/main/anaconda/envs/python3/bin/pip install -r requirements.txt
+RUN /home/main/anaconda2/envs/python3/bin/pip install -r requirements.txt


### PR DESCRIPTION
docker build breaks because of a broken path for anaconda. this patch changes "anaconda" to "anaconda2"
